### PR TITLE
Add optional boolean input parameter 'schedule'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   token:
     description: 'GitLab API access token'
     required: true
+  schedule:
+    description: 'Indication if it is a automatically scheduled request'
+    required: false
+    default: false
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ async function main() {
     const id = core.getInput('project-id', { required: true });
     const ref = core.getInput('ref', { required: true });
     const token = core.getInput('token', { required: true });
+    const schedule = core.getBooleanInput('schedule', { required: false });
 
     const client = new http.HttpClient();
     const url = new URL(`projects/${id}/trigger/pipeline`, apiUrl);
@@ -34,6 +35,7 @@ async function main() {
     url.searchParams.append('variables[GITHUB_REF_TYPE]', process.env.GITHUB_REF_TYPE);
     url.searchParams.append('variables[GITHUB_REPO]', `${repo.repo}`);
     url.searchParams.append('variables[GITHUB_SHA]', sha);
+    url.searchParams.append('variables[GITHUB_SCHEDULE]', schedule);
 
     let res;
     try {


### PR DESCRIPTION
This parameter is passed as is to the underlying gitlab pipeline to let it know that the pipeline is automatically scheduled, not a result of some action from commiters. It will be used to collect statistics of failed jobs for nightly scheduled pipelines.

I'm not adding generic system to pass arbitrary variables to avoid security issues.