### PR TITLE
Add support for private repositories

### DIFF
--- a/.github/workflows/trigger-gitlab-pipeline.yml
+++ b/.github/workflows/trigger-gitlab-pipeline.yml
@@ -29,6 +29,9 @@ on:
       project-id:
         description: 'GitLab project ID'
         required: true
+      github-token:
+        description: 'GitHub token required only for private repositories'
+        required: false
 
 jobs:
   authorize-and-resolve-workflow-ref:
@@ -46,6 +49,8 @@ jobs:
         with:
           repository-name: NordSecurity/trigger-gitlab-pipeline
           file-name: trigger-gitlab-pipeline.yml
+          # Only required for private repositories
+          github-token: ${{ secrets.github-token }}
     outputs:
       workflow-ref: ${{ steps.workflow-ref.outputs.sha }}
 


### PR DESCRIPTION
When the repository is private `canonical/get-workflow-version-action` is not able to access it. Because of this the pipeline cannot be triggered.