### PR TITLE
Update canonical/get-workflow-version-action to v1.0.1

### DIFF
--- a/.github/workflows/trigger-gitlab-pipeline.yml
+++ b/.github/workflows/trigger-gitlab-pipeline.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "Authorized the job to run" # This step will only execute if
                                               # the pipeline has necessary approvals to run
       - name: Resolve Workflow Version
-        uses: canonical/get-workflow-version-action@a5d53b08d254a157ea441c9819ea5002ffc12edc
+        uses: canonical/get-workflow-version-action@88281a62e96e1c0ef4df30352ae0668a9f3e3369
         id: workflow-ref
         with:
           repository-name: NordSecurity/trigger-gitlab-pipeline


### PR DESCRIPTION
v1.0.0 has a minor security issue where the GITHUB_TOKEN can be partially leaked if the the get-workflow-version-action step fails

This repository is not impacted since the `github-token` input of the `get-workflow-version-action` is not used. However, if the `github-token` input was added to this repository in the future, this repository would become impacted if v1.0.0 was used

More information: https://github.com/canonical/get-workflow-version-action/issues/2