### PR TITLE
Make authenticated requests in authorize-and-resolve-workflow-ref

### DIFF
--- a/.github/workflows/trigger-gitlab-pipeline.yml
+++ b/.github/workflows/trigger-gitlab-pipeline.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           repository-name: NordSecurity/trigger-gitlab-pipeline
           file-name: trigger-gitlab-pipeline.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       workflow-ref: ${{ steps.workflow-ref.outputs.sha }}
 


### PR DESCRIPTION
We're hitting the rate limit for the requests while calling below requests in [get-workflow-version-action](https://github.com/canonical/get-workflow-version-action/tree/main):
```
requests.get(
        f"{github_api_url}/repos/{caller_repository}/actions/runs/{caller_run_id}",
        headers=headers,
    )
```
With [authenticated](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions) requests we might increase the limit.
